### PR TITLE
Fix: async race condition in keep tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Tab-Options",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Detect & merge duplicate tabs, group by domain, save sessions, export/import tabs. Lightweight & open source.",
   "scripts": {
     "copy-manifest:chrome": "node scripts/copy-manifest.js chrome",

--- a/src/background.js
+++ b/src/background.js
@@ -322,13 +322,10 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
     }
 
     if (message.action === 'keepTab' || message.action === 'promptClosed') {
-      // Remember this tab/url combination so we don't prompt again immediately
-      // We need to get the current URL of the tab to store it correctly
-      browser.tabs.get(tabId).then((tab) => {
-        if (tab && tab.url) {
-          keptTabs.set(tabId, getTabKey(tab.url));
-        }
-      });
+      // Remember this tab/url combination so we don't prompt again on refresh
+      if (sender.tab && sender.tab.url) {
+        keptTabs.set(tabId, getTabKey(sender.tab.url));
+      }
     }
 
     if (message.action === 'goBack') {

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Tab Options - Open Source",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Detect & merge duplicate tabs, group by domain, save sessions, export/import tabs. Lightweight & open source.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["<all_urls>"],

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Tab Options - Open Source",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Detect & merge duplicate tabs, group by domain, save sessions, export/import tabs. Lightweight & open source.",
   "permissions": ["tabs", "scripting", "storage"],
   "host_permissions": ["<all_urls>"],


### PR DESCRIPTION
This **PR** fixes a race condition in the keep tab flow.

`sender.tab.url` was available synchronously in the message handler, no need for another `tabs.get` call. The async callback could run after the tab was already closed, causing the kept-tab record to never be saved — and the next refresh would trigger the duplicate prompt again.

- [x] use `sender.tab.url` instead of `browser.tabs.get().then()`
- [x] bump version to 1.6.1